### PR TITLE
feat(frontend): code changes to add env vars and make AMS URL available

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -38,7 +38,12 @@ jobs:
       environment: test
       tag: ${{ needs.vars.outputs.pr }}
       release: test
-      params: --set backend.deploymentStrategy=RollingUpdate --set frontend.deploymentStrategy=RollingUpdate --set backend.pdb.enabled=false --set frontend.pdb.enabled=false
+      params: |
+        --set backend.deploymentStrategy=RollingUpdate \
+        --set frontend.deploymentStrategy=RollingUpdate \
+        --set backend.pdb.enabled=false \
+        --set frontend.pdb.enabled=false \
+        --set-string global.amsURL=https://j200.gov.bc.ca/pub/ams/
   tests:
     name: Tests
     needs: [ deploy-test ]
@@ -55,7 +60,12 @@ jobs:
       environment: prod
       tag: ${{ needs.vars.outputs.pr }}
       release: prod
-      params: --set backend.deploymentStrategy=RollingUpdate --set frontend.deploymentStrategy=RollingUpdate --set backend.pdb.enabled=false --set frontend.pdb.enabled=false
+      params: |
+        --set backend.deploymentStrategy=RollingUpdate \
+        --set frontend.deploymentStrategy=RollingUpdate \
+        --set backend.pdb.enabled=false \
+        --set frontend.pdb.enabled=false \
+        --set-string global.amsURL=https://j200.gov.bc.ca/pub/ams/
 
   promote:
     name: Promote Images

--- a/charts/nr-epd-organics-info/templates/frontend/templates/deployment.yaml
+++ b/charts/nr-epd-organics-info/templates/frontend/templates/deployment.yaml
@@ -39,6 +39,8 @@ spec:
               value: "http://{{ .Release.Name }}-backend"
             - name: LOG_LEVEL
               value: "info"
+            - name: VITE_AMS_URL
+              value: {{ .Values.global.amsURL }}
           ports:
             - name: http
               containerPort: 3000

--- a/charts/nr-epd-organics-info/values.yaml
+++ b/charts/nr-epd-organics-info/values.yaml
@@ -24,7 +24,7 @@ global:
     osEndpoint: ~
   #-- domain of the application, it is required, apps.silver.devops.gov.bc.ca for silver cluster and apps.devops.gov.bc.ca for gold cluster
   domain: "apps.silver.devops.gov.bc.ca" # it is apps.gold.devops.gov.bc.ca for gold cluster
-  amsURL: https://test.j200.gov.bc.ca/pub/ams/
+  amsURL: "https://test.j200.gov.bc.ca/pub/ams/"
   #-- the database Alias gives a nice way to switch to different databases, crunchy, patroni ... etc.
 
 #-- the components of the application, backend.

--- a/charts/nr-epd-organics-info/values.yaml
+++ b/charts/nr-epd-organics-info/values.yaml
@@ -24,6 +24,7 @@ global:
     osEndpoint: ~
   #-- domain of the application, it is required, apps.silver.devops.gov.bc.ca for silver cluster and apps.devops.gov.bc.ca for gold cluster
   domain: "apps.silver.devops.gov.bc.ca" # it is apps.gold.devops.gov.bc.ca for gold cluster
+  amsURL: https://test.j200.gov.bc.ca/pub/ams/
   #-- the database Alias gives a nice way to switch to different databases, crunchy, patroni ... etc.
 
 #-- the components of the application, backend.

--- a/frontend/.env.sample
+++ b/frontend/.env.sample
@@ -1,1 +1,3 @@
-PORT=3001
+VITE_PORT=3001
+VITE_AMS_URL=https://test.j200.gov.bc.ca/pub/ams/
+VITE_API_URL=https://nr-epd-organics-info-test-frontend.apps.silver.devops.gov.bc.ca

--- a/frontend/Caddyfile
+++ b/frontend/Caddyfile
@@ -18,7 +18,7 @@
         header {
           Content-Type text/javascript
         }
-        respond `window.config={"VITE_AMS_URL":"{$AMS_URL}"};`
+        respond `window.config={"VITE_AMS_URL":"{$VITE_AMS_URL}"};`
     }
 	root * /srv
 	encode zstd gzip

--- a/frontend/Caddyfile
+++ b/frontend/Caddyfile
@@ -14,11 +14,17 @@
 		}
 		level {$LOG_LEVEL}
 	}
+    handle /env.js {
+        header {
+          Content-Type text/javascript
+        }
+        respond `window.config={"VITE_AMS_URL":"{$AMS_URL}"};`
+    }
 	root * /srv
 	encode zstd gzip
 	file_server
 	@spa_router {
-		not path /api/*
+		not path /api/* /env.js
 		file {
 			try_files {path} /index.html
 		}

--- a/frontend/src/env.ts
+++ b/frontend/src/env.ts
@@ -1,0 +1,8 @@
+declare global {
+  // eslint-disable-next-line no-unused-vars
+  interface Window {
+    config: any
+  }
+}
+
+export const env: Record<string, any> = { ...import.meta.env, ...window.config };

--- a/frontend/src/service/api-service.ts
+++ b/frontend/src/service/api-service.ts
@@ -1,6 +1,6 @@
 import type { AxiosInstance } from 'axios'
 import axios from 'axios'
-
+import {env} from '@/env'
 import { isTest } from '@/constants/env'
 
 class APIService {
@@ -26,6 +26,7 @@ class APIService {
         }
       },
     )
+    console.info(env.VITE_AMS_URL)
   }
 
   public getAxiosInstance(): AxiosInstance {

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -16,7 +16,7 @@ export default ({ mode }) => {
   return defineConfig({
     plugins: [react(), svgr()],
     server: {
-      port: 3001, //parseInt(process.env.PORT),
+      port: parseInt(process.env.VITE_PORT) || 3001,
       fs: {
         // Allow serving files from one level up to the project root
         allow: ['..'],

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,4 +1,4 @@
-import { loadEnv, defineConfig } from 'vite'
+import { defineConfig, loadEnv } from 'vite'
 import { configDefaults } from 'vitest/config'
 import { fileURLToPath, URL } from 'node:url'
 import react from '@vitejs/plugin-react'
@@ -14,7 +14,28 @@ export default ({ mode }) => {
   }
 
   return defineConfig({
-    plugins: [react(), svgr()],
+    plugins: [
+      {
+        name: 'build-html',
+        apply: 'build',
+        transformIndexHtml: (html) => {
+          return {
+            html,
+            tags: [
+              {
+                tag: 'script',
+                attrs: {
+                  src: '/env.js',
+                },
+                injectTo: 'head',
+              },
+            ],
+          }
+        },
+      },
+      react(),
+      svgr()
+    ],
     server: {
       port: parseInt(process.env.VITE_PORT) || 3001,
       fs: {

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -24,7 +24,7 @@ export default ({ mode }) => {
       proxy: {
         // Proxy API requests to the backend
         '/api': {
-          target: 'http://localhost:3000',
+          target: process.env.VITE_API_URL,
           changeOrigin: true,
         },
       },


### PR DESCRIPTION
1. Added AMS(Posse) URL as env var
2. Some modifications to code have configs as env vars from hardcoded values.


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-epd-organics-info-179-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-epd-organics-info-179-frontend.apps.silver.devops.gov.bc.ca/api/)

Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-epd-organics-info/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-epd-organics-info/actions/workflows/merge.yml)