### PR TITLE
feat: Authorization documents

### DIFF
--- a/frontend/e2e/pages/auth.details.ts
+++ b/frontend/e2e/pages/auth.details.ts
@@ -33,8 +33,6 @@ export const authorization_details_page = async (page: Page) => {
     page.getByText('Schedule 2 - Composting Operations'),
   ).toBeVisible()
 
-  await expect(page.getByText('Documents', { exact: true })).toBeVisible()
-
   const backBtn = page.getByRole('button', { name: 'Back to Text Search' })
   await expect(backBtn).toBeVisible()
   await backBtn.click()

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -1,8 +1,28 @@
+import { useSelector } from 'react-redux'
 import { screen } from '@testing-library/react'
 
 import App from '@/App'
 import { render } from '@/test-utils'
-import { initialState } from '@/features/omrr/omrr-slice'
+import {
+  initialState,
+  selectAllResults,
+  selectStatus as selectOmrrStatus,
+} from '@/features/omrr/omrr-slice'
+import {
+  selectAllDocuments,
+  useDocumentsStatus,
+} from '@/features/omrr/documents-slice'
+import {
+  selectAllApplications,
+  selectStatus as selectApplicationStatus,
+} from '@/features/omrr/applications-slice'
+import OmrrData from '@/interfaces/omrr'
+import { OmrrApplicationStatus } from '@/interfaces/omrr-application-status'
+import { OmrrAuthzDocsResponse } from '@/interfaces/omrr-documents'
+import { LoadingStatusType } from '@/interfaces/loading-status'
+import { mockOmrrData } from '@/mocks/mock-omrr-data'
+import { mockOmrrApplicationStatusResponse } from '@/mocks/mock-omrr-application-status'
+import { mockOmrrDocuments } from '@/mocks/mock-omrr-documents'
 
 describe('App suite', () => {
   test('renders the App with idle state', () => {
@@ -64,5 +84,51 @@ describe('App suite', () => {
     screen.getByAltText('Logo')
     screen.getByText('Organics Info')
     screen.getByText('Loading failed, please try again later')
+  })
+
+  test('renders the App and loads API data using MSW', async () => {
+    interface State {
+      allResults?: OmrrData[]
+      omrrStatus?: LoadingStatusType
+      allApplications?: OmrrApplicationStatus[]
+      applicationStatus?: LoadingStatusType
+      allDocuments?: OmrrAuthzDocsResponse[]
+      documentStatus?: LoadingStatusType
+    }
+    const state: State = {}
+
+    const TestComponent = () => {
+      Object.assign(state, {
+        allResults: useSelector(selectAllResults),
+        omrrStatus: useSelector(selectOmrrStatus),
+        allApplications: useSelector(selectAllApplications),
+        applicationStatus: useSelector(selectApplicationStatus),
+        allDocuments: useSelector(selectAllDocuments),
+        documentStatus: useDocumentsStatus(),
+      })
+      return <App />
+    }
+    render(<TestComponent />, {
+      withStateProvider: true,
+      withApiData: true,
+    })
+
+    await screen.findByText(
+      'Find an authorized compost and biosolid facility in British Columbia',
+    )
+    // Ensure state is set properly
+    expect(state.allResults).toBeDefined()
+    expect(state.allResults).toHaveLength(mockOmrrData.length)
+    expect(state.omrrStatus).toBe('succeeded')
+
+    expect(state.allApplications).toBeDefined()
+    expect(state.allApplications).toHaveLength(
+      mockOmrrApplicationStatusResponse.length,
+    )
+    expect(state.applicationStatus).toBe('succeeded')
+
+    expect(state.allDocuments).toBeDefined()
+    expect(state.allDocuments).toHaveLength(mockOmrrDocuments.length)
+    expect(state.documentStatus).toBe('succeeded')
   })
 })

--- a/frontend/src/app/store.ts
+++ b/frontend/src/app/store.ts
@@ -25,9 +25,10 @@ export function setupStore(preloadedState?: Partial<RootState>) {
 }
 
 export const store = setupStore()
+type StoreType = typeof store
 
 // Load initial data from the API
-export function loadApiData() {
+export function loadApiData(store: StoreType) {
   store.dispatch(fetchOMRRData())
   store.dispatch(fetchOmrrApplicationStatus())
   store.dispatch(fetchOmrrDocuments())

--- a/frontend/src/app/store.ts
+++ b/frontend/src/app/store.ts
@@ -2,13 +2,18 @@ import { combineReducers, configureStore } from '@reduxjs/toolkit'
 import { fetchOMRRData, omrrSlice } from '@/features/omrr/omrr-slice'
 import { mapSlice } from '@/features/map/map-slice'
 import {
-  applicationStatusSlice,
+  applicationsSlice,
   fetchOmrrApplicationStatus,
-} from '@/features/omrr/application-status-slice'
+} from '@/features/omrr/applications-slice'
+import {
+  documentsSlice,
+  fetchOmrrDocuments,
+} from '@/features/omrr/documents-slice'
 
 const rootReducer = combineReducers({
   omrr: omrrSlice.reducer,
-  applicationStatus: applicationStatusSlice.reducer,
+  applications: applicationsSlice.reducer,
+  documents: documentsSlice.reducer,
   map: mapSlice.reducer,
 })
 
@@ -25,6 +30,7 @@ export const store = setupStore()
 export function loadApiData() {
   store.dispatch(fetchOMRRData())
   store.dispatch(fetchOmrrApplicationStatus())
+  store.dispatch(fetchOmrrDocuments())
 }
 
 // Infer the `RootState` and `AppDispatch` types from the store itself

--- a/frontend/src/components/AppError.tsx
+++ b/frontend/src/components/AppError.tsx
@@ -2,6 +2,7 @@ import { useSelector } from 'react-redux'
 import { Snackbar } from '@mui/material'
 import { useTheme } from '@mui/material/styles'
 
+import { isTest } from '@/constants/env'
 import { selectError } from '@/features/omrr/omrr-slice'
 
 export default function AppError() {
@@ -11,7 +12,9 @@ export default function AppError() {
     backgroundColor: theme.palette.error.main,
     color: theme.palette.secondary.main,
   }
-  console.info('App error:', error)
+  if (!isTest) {
+    console.info('App error:', error)
+  }
 
   return (
     <Snackbar

--- a/frontend/src/components/AuthorizationStatusChip.css
+++ b/frontend/src/components/AuthorizationStatusChip.css
@@ -1,4 +1,4 @@
-.authorization-status-chip {
+div.authorization-status-chip {
   color: #ffffff;
   background-color: var(--icons-color-disabled);
   display: inline-flex;
@@ -14,12 +14,12 @@
   padding: 0;
 }
 
-.authorization-status-chip--small {
+div.authorization-status-chip--small {
   height: 24px;
   font-size: 14px;
   padding: 0 var(--layout-padding-medium);
 }
 
-.authorization-status-chip--active {
+div.authorization-status-chip--active {
   background-color: var(--support-border-color-success);
 }

--- a/frontend/src/components/AuthorizationStatusChip.css
+++ b/frontend/src/components/AuthorizationStatusChip.css
@@ -1,0 +1,25 @@
+.authorization-status-chip {
+  color: #ffffff;
+  background-color: var(--icons-color-disabled);
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  height: 40px;
+  padding: 0 var(--layout-padding-large);
+  font-size: 16px;
+  border-radius: 24px;
+}
+
+.authorization-status-chip .MuiChip-label {
+  padding: 0;
+}
+
+.authorization-status-chip--small {
+  height: 24px;
+  font-size: 14px;
+  padding: 0 var(--layout-padding-medium);
+}
+
+.authorization-status-chip--active {
+  background-color: var(--support-border-color-success);
+}

--- a/frontend/src/components/AuthorizationStatusChip.tsx
+++ b/frontend/src/components/AuthorizationStatusChip.tsx
@@ -1,4 +1,7 @@
 import { Chip } from '@mui/material'
+import clsx from 'clsx'
+
+import './AuthorizationStatusChip.css'
 
 interface Props {
   status: string
@@ -12,18 +15,13 @@ export function AuthorizationStatusChip({
   const isActive = status === 'Active'
   return (
     <Chip
-      sx={{
-        color: '#ffffff',
-        backgroundColor: isActive ? '#42814a' : '#9f9d9c',
-        display: 'inline-flex',
-        height: size === 'small' ? '24px' : '40px',
-        fontSize: size === 'small' ? '14px' : '16px',
-        padding: '0 12px',
-        borderRadius: '24px',
-        justifyContent: 'center',
-        alignItems: 'center',
-      }}
+      className={clsx(
+        'authorization-status-chip',
+        `authorization-status-chip--${size}`,
+        isActive && 'authorization-status-chip--active',
+      )}
       label={status}
+      size={size}
     />
   )
 }

--- a/frontend/src/components/DataLayersCheckboxGroup.tsx
+++ b/frontend/src/components/DataLayersCheckboxGroup.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { useDispatch } from 'react-redux'
 import { Button, Stack, Typography } from '@mui/material'
 import clsx from 'clsx'

--- a/frontend/src/components/DropdownButton.test.tsx
+++ b/frontend/src/components/DropdownButton.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { screen } from '@testing-library/react'
 
 import { render } from '@/test-utils'

--- a/frontend/src/components/FilterByCheckboxGroup.tsx
+++ b/frontend/src/components/FilterByCheckboxGroup.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import {
   Button,

--- a/frontend/src/components/HorizontalScroller.test.tsx
+++ b/frontend/src/components/HorizontalScroller.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { screen } from '@testing-library/react'
 
 import { render } from '@/test-utils'

--- a/frontend/src/components/LocationIconButton.tsx
+++ b/frontend/src/components/LocationIconButton.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { useDispatch } from 'react-redux'
 import { IconButton } from '@mui/material'
 

--- a/frontend/src/components/NoResults.tsx
+++ b/frontend/src/components/NoResults.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { useDispatch } from 'react-redux'
 import { Button, Stack, Typography } from '@mui/material'
 

--- a/frontend/src/constants/data-layers.ts
+++ b/frontend/src/constants/data-layers.ts
@@ -186,7 +186,7 @@ export const DATA_LAYER_GROUPS: DataLayerGroup[] = [
         name: 'PMBC Parcel Cadastre',
         url: `${BASE_URL}/WHSE_CADASTRE.PMBC_PARCEL_FABRIC_POLY_SVW/ows`,
         layers: 'pub:WHSE_CADASTRE.PMBC_PARCEL_FABRIC_POLY_SVW',
-        styles: '5898',
+        styles: '5899', // Provincial Crown Lands
       },
     ],
   },

--- a/frontend/src/features/omrr/applications-slice.ts
+++ b/frontend/src/features/omrr/applications-slice.ts
@@ -12,12 +12,6 @@ import { OmrrApplicationStatus } from '@/interfaces/omrr-application-status'
 import apiService from '@/service/api-service'
 import { truncateDate } from '@/utils/utils'
 
-export interface ApplicationStatusSliceState {
-  status: LoadingStatusType
-  error?: string
-  allApplications: OmrrApplicationStatus[]
-}
-
 export const fetchOmrrApplicationStatus = createAsyncThunk(
   'data/fetchOmrrApplicationStatus',
   async () => {
@@ -28,19 +22,23 @@ export const fetchOmrrApplicationStatus = createAsyncThunk(
   },
 )
 
-export const initialState: ApplicationStatusSliceState = {
+export interface ApplicationsSliceState {
+  status: LoadingStatusType
+  error?: string
+  allApplications: OmrrApplicationStatus[]
+}
+
+export const initialState: ApplicationsSliceState = {
   status: 'idle',
   error: undefined,
   allApplications: [],
 }
 
-export const applicationStatusSlice = createSlice({
-  name: 'applicationStatus',
+export const applicationsSlice = createSlice({
+  name: 'applications',
   initialState,
   reducers: {},
-  extraReducers: (
-    builder: ActionReducerMapBuilder<ApplicationStatusSliceState>,
-  ) => {
+  extraReducers: (builder: ActionReducerMapBuilder<ApplicationsSliceState>) => {
     builder.addCase(fetchOmrrApplicationStatus.pending, (state) => {
       state.status = 'loading'
     })
@@ -71,15 +69,11 @@ export const applicationStatusSlice = createSlice({
   },
 })
 
-// export const {} = applicationStatusSlice.actions
-
-// export default applicationStatusSlice.reducer
-
 // Selectors
-//export const selectStatus = (state: RootState) => state.applicationStatus.status
+export const selectStatus = (state: RootState) => state.applications.status
 //export const selectError = (state: RootState) => state.applicationStatus.error
 export const selectAllApplications = (state: RootState) =>
-  state.applicationStatus.allApplications
+  state.applications.allApplications
 
 export const useFindApplicationStatus = (
   authorizationNumber: number,

--- a/frontend/src/features/omrr/documents-slice.ts
+++ b/frontend/src/features/omrr/documents-slice.ts
@@ -1,0 +1,116 @@
+import { useSelector } from 'react-redux'
+import {
+  ActionReducerMapBuilder,
+  createAsyncThunk,
+  createSlice,
+  PayloadAction,
+} from '@reduxjs/toolkit'
+
+import { RootState } from '@/app/store'
+import { LoadingStatusType } from '@/interfaces/loading-status'
+import apiService from '@/service/api-service'
+import {
+  OmrrAuthzDocs,
+  OmrrAuthzDocsResponse,
+} from '@/interfaces/omrr-documents'
+
+export const fetchOmrrDocuments = createAsyncThunk(
+  'data/fetchOmrrDocuments',
+  async () => {
+    const result = await apiService
+      .getAxiosInstance()
+      .get('/omrr/authorization-docs')
+    return result?.data
+  },
+)
+
+export interface DocumentsSliceState {
+  status: LoadingStatusType
+  error?: string
+  allDocuments: OmrrAuthzDocsResponse[]
+}
+
+export const initialState: DocumentsSliceState = {
+  status: 'idle',
+  error: undefined,
+  allDocuments: [],
+}
+
+export const documentsSlice = createSlice({
+  name: 'documents',
+  initialState,
+  reducers: {},
+  extraReducers: (builder: ActionReducerMapBuilder<DocumentsSliceState>) => {
+    builder.addCase(fetchOmrrDocuments.pending, (state) => {
+      state.status = 'loading'
+    })
+    builder.addCase(
+      fetchOmrrDocuments.fulfilled,
+      (state, action: PayloadAction<OmrrAuthzDocsResponse[]>) => {
+        const data: OmrrAuthzDocsResponse[] = action.payload
+        if (Array.isArray(data) && data.length === 0) {
+          // TESTING
+          data.push({
+            'Authorization Number': 12398,
+            doc_links: [
+              {
+                DocumentObjectID: 1,
+                Description: 'document.pdf',
+                Publiclyviewable: '',
+              },
+              {
+                DocumentObjectID: 2,
+                Description: 'sample.pdf',
+                Publiclyviewable: '',
+              },
+              {
+                DocumentObjectID: 3,
+                Description: 'trouble.pdf',
+                Publiclyviewable: '',
+              },
+            ],
+          })
+        }
+        if (Array.isArray(data) && data.length > 0) {
+          state.status = 'succeeded'
+          state.allDocuments = data
+        } else {
+          state.status = 'failed'
+          state.error = 'No data found'
+          console.log('No authorization documents loaded.')
+        }
+      },
+    )
+    builder.addCase(fetchOmrrDocuments.rejected, (state, action) => {
+      state.status = 'failed'
+      state.error = action.error.message
+      console.error(
+        'Failed to load authorization documents',
+        action.error.message,
+      )
+    })
+  },
+})
+
+// Selectors
+export const selectStatus = (state: RootState) => state.documents.status
+export const useDocumentsStatus = () => useSelector(selectStatus)
+
+export const selectAllDocuments = (state: RootState) =>
+  state.documents.allDocuments
+
+export const useFindAuthorizationDocuments = (
+  authorizationNumber: number,
+): OmrrAuthzDocs[] | undefined => {
+  const allDocuments = useSelector(selectAllDocuments)
+  if (authorizationNumber > 0) {
+    const response = allDocuments.find(
+      (response: OmrrAuthzDocsResponse) =>
+        response['Authorization Number'] === authorizationNumber,
+    )
+    if (response) {
+      return response.doc_links
+    }
+  }
+  return undefined
+}

--- a/frontend/src/features/omrr/documents-slice.ts
+++ b/frontend/src/features/omrr/documents-slice.ts
@@ -48,29 +48,6 @@ export const documentsSlice = createSlice({
       fetchOmrrDocuments.fulfilled,
       (state, action: PayloadAction<OmrrAuthzDocsResponse[]>) => {
         const data: OmrrAuthzDocsResponse[] = action.payload
-        if (Array.isArray(data) && data.length === 0) {
-          // TESTING
-          data.push({
-            'Authorization Number': 12398,
-            doc_links: [
-              {
-                DocumentObjectID: 1,
-                Description: 'document.pdf',
-                Publiclyviewable: '',
-              },
-              {
-                DocumentObjectID: 2,
-                Description: 'sample.pdf',
-                Publiclyviewable: '',
-              },
-              {
-                DocumentObjectID: 3,
-                Description: 'trouble.pdf',
-                Publiclyviewable: '',
-              },
-            ],
-          })
-        }
         if (Array.isArray(data) && data.length > 0) {
           state.status = 'succeeded'
           state.allDocuments = data

--- a/frontend/src/features/omrr/omrr-slice.ts
+++ b/frontend/src/features/omrr/omrr-slice.ts
@@ -231,7 +231,7 @@ export const useSearchTextFilter = () => useSelector(selectSearchTextFilter)
 export const useHasSearchTextFilter = () =>
   useSearchTextFilter().length >= MIN_SEARCH_LENGTH
 
-const selectAllResults = (state: RootState) => state.omrr.allResults
+export const selectAllResults = (state: RootState) => state.omrr.allResults
 const selectAllResultsCount = (state: RootState) => state.omrr.allResults.length
 
 export const selectFilteredResults = (state: RootState) =>

--- a/frontend/src/interfaces/omrr-documents.ts
+++ b/frontend/src/interfaces/omrr-documents.ts
@@ -1,0 +1,10 @@
+export interface OmrrAuthzDocs {
+  DocumentObjectID: number
+  Description: string
+  Publiclyviewable: string
+}
+
+export interface OmrrAuthzDocsResponse {
+  'Authorization Number': number
+  doc_links?: OmrrAuthzDocs[]
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -11,7 +11,7 @@ import { loadApiData, store } from './app/store'
 import './index.css'
 
 // Load initial API data
-loadApiData()
+loadApiData(store)
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>

--- a/frontend/src/mocks/mock-omrr-application-status.ts
+++ b/frontend/src/mocks/mock-omrr-application-status.ts
@@ -1,4 +1,6 @@
-export const mockOmrrApplicationStatusResponse = [
+import { OmrrApplicationStatus } from '@/interfaces/omrr-application-status'
+
+export const mockOmrrApplicationStatusResponse: OmrrApplicationStatus[] = [
   {
     Status: 'In Review',
     'Authorization Number': 108485,

--- a/frontend/src/mocks/mock-omrr-documents.ts
+++ b/frontend/src/mocks/mock-omrr-documents.ts
@@ -1,0 +1,23 @@
+import { OmrrAuthzDocsResponse } from '@/interfaces/omrr-documents'
+
+export const mockOmrrDocuments: OmrrAuthzDocsResponse[] = [
+  {
+    'Authorization Number': 108485,
+    doc_links: [
+      {
+        DocumentObjectID: 1,
+        Description: 'test-file.pdf',
+        Publiclyviewable: '',
+      },
+      {
+        DocumentObjectID: 2,
+        Description: 'sample-file.pdf',
+        Publiclyviewable: '',
+      },
+    ],
+  },
+  {
+    'Authorization Number': 11123,
+    doc_links: [],
+  },
+]

--- a/frontend/src/pages/authorizationDetails/ApplicationStatusSection.tsx
+++ b/frontend/src/pages/authorizationDetails/ApplicationStatusSection.tsx
@@ -1,8 +1,11 @@
-import React from 'react'
+import { useSelector } from 'react-redux'
 import { Link, Stack, Typography } from '@mui/material'
 
 import OmrrData from '@/interfaces/omrr'
-import { useFindApplicationStatus } from '@/features/omrr/application-status-slice'
+import {
+  selectStatus,
+  useFindApplicationStatus,
+} from '@/features/omrr/applications-slice'
 import { OmrrApplicationStatus } from '@/interfaces/omrr-application-status'
 
 import './ApplicationStatusSection.css'
@@ -13,14 +16,15 @@ interface Props {
 
 /**
  * Displays the details about an application status.
- * If there is no application status then null is returned and nothing is shown.
+ * If there are no application status items then null is returned and nothing is shown.
  */
 export function ApplicationStatusSection({ item }: Readonly<Props>) {
   const number = item['Authorization Number']
+  const status = useSelector(selectStatus)
   const allApplications: OmrrApplicationStatus[] =
     useFindApplicationStatus(number)
 
-  if (allApplications.length === 0) {
+  if (status !== 'succeeded' || allApplications.length === 0) {
     return null
   }
 

--- a/frontend/src/pages/authorizationDetails/AuthorizationDetails.test.tsx
+++ b/frontend/src/pages/authorizationDetails/AuthorizationDetails.test.tsx
@@ -7,6 +7,7 @@ import { mockOmrrData } from '@/mocks/mock-omrr-data'
 import { initialState } from '@/features/omrr/omrr-slice'
 import { mockOmrrApplicationStatusResponse } from '@/mocks/mock-omrr-application-status'
 import AuthorizationDetails from './AuthorizationDetails'
+import { mockOmrrDocuments } from '@/mocks/mock-omrr-documents'
 
 describe('Test suite for AuthorizationDetails', () => {
   function renderComponent(
@@ -126,15 +127,9 @@ describe('Test suite for AuthorizationDetails', () => {
   })
 
   it('should render AuthorizationDetails with no documents', async () => {
+    // this one has no documents
     const number = 11123
-    const documents: OmrrAuthzDocsResponse[] = [
-      {
-        'Authorization Number': number,
-        doc_links: [],
-      },
-    ]
-
-    renderComponent(number, documents)
+    renderComponent(number, mockOmrrDocuments)
 
     screen.getByText('Documents')
     screen.getByText('File Description')
@@ -142,32 +137,13 @@ describe('Test suite for AuthorizationDetails', () => {
   })
 
   it('should render AuthorizationDetails with documents', async () => {
+    // This one has 2 documents
     const number = 108485
-    const description1 = 'test-file.pdf'
-    const description2 = 'test-report.pdf'
-    const documents: OmrrAuthzDocsResponse[] = [
-      {
-        'Authorization Number': number,
-        doc_links: [
-          {
-            DocumentObjectID: 1,
-            Description: description1,
-            Publiclyviewable: '',
-          },
-          {
-            DocumentObjectID: 2,
-            Description: description2,
-            Publiclyviewable: '',
-          },
-        ],
-      },
-    ]
-
-    renderComponent(number, documents)
+    renderComponent(number, mockOmrrDocuments)
 
     screen.getByText('Documents')
     screen.getByText('File Description')
-    screen.getByText(description1)
-    screen.getByText(description2)
+    screen.getByText('test-file.pdf')
+    screen.getByText('sample-file.pdf')
   })
 })

--- a/frontend/src/pages/authorizationDetails/AuthorizationDetails.test.tsx
+++ b/frontend/src/pages/authorizationDetails/AuthorizationDetails.test.tsx
@@ -2,13 +2,17 @@ import { getByText, screen, waitFor } from '@testing-library/react'
 
 import { render } from '@/test-utils'
 import OmrrData from '@/interfaces/omrr'
+import { OmrrAuthzDocsResponse } from '@/interfaces/omrr-documents'
 import { mockOmrrData } from '@/mocks/mock-omrr-data'
 import { initialState } from '@/features/omrr/omrr-slice'
 import { mockOmrrApplicationStatusResponse } from '@/mocks/mock-omrr-application-status'
 import AuthorizationDetails from './AuthorizationDetails'
 
 describe('Test suite for AuthorizationDetails', () => {
-  function renderComponent(authorizationNumber: number) {
+  function renderComponent(
+    authorizationNumber: number,
+    allDocuments: OmrrAuthzDocsResponse[] | undefined = [],
+  ) {
     const { user } = render(<AuthorizationDetails />, {
       withRouter: true,
       route: `/authorization/${authorizationNumber}`,
@@ -20,9 +24,13 @@ describe('Test suite for AuthorizationDetails', () => {
           allResults: mockOmrrData,
           searchByFilteredResults: mockOmrrData,
         },
-        applicationStatus: {
+        applications: {
           status: 'succeeded',
           allApplications: mockOmrrApplicationStatusResponse,
+        },
+        documents: {
+          status: allDocuments.length > 0 ? 'succeeded' : 'failed',
+          allDocuments,
         },
       },
     })
@@ -92,9 +100,7 @@ describe('Test suite for AuthorizationDetails', () => {
     screen.getByRole('link', { name: 'Organic Matter Recycling Regulation' })
     screen.getByText(/^Please note that authorizations issued/)
 
-    screen.getByText('Documents')
-    screen.getByText('File Description')
-    screen.getByText('There are no documents to display.')
+    expect(screen.queryByText('Documents')).not.toBeInTheDocument()
   })
 
   it('should render AuthorizationDetails with application status', async () => {
@@ -117,5 +123,51 @@ describe('Test suite for AuthorizationDetails', () => {
 
     screen.getByText(/^Applies to amendment and new notifications only/)
     // screen.getByRole('link', { name: 'please see our guidance on data we show' })
+  })
+
+  it('should render AuthorizationDetails with no documents', async () => {
+    const number = 11123
+    const documents: OmrrAuthzDocsResponse[] = [
+      {
+        'Authorization Number': number,
+        doc_links: [],
+      },
+    ]
+
+    renderComponent(number, documents)
+
+    screen.getByText('Documents')
+    screen.getByText('File Description')
+    screen.getByText('There are no documents to display.')
+  })
+
+  it('should render AuthorizationDetails with documents', async () => {
+    const number = 108485
+    const description1 = 'test-file.pdf'
+    const description2 = 'test-report.pdf'
+    const documents: OmrrAuthzDocsResponse[] = [
+      {
+        'Authorization Number': number,
+        doc_links: [
+          {
+            DocumentObjectID: 1,
+            Description: description1,
+            Publiclyviewable: '',
+          },
+          {
+            DocumentObjectID: 2,
+            Description: description2,
+            Publiclyviewable: '',
+          },
+        ],
+      },
+    ]
+
+    renderComponent(number, documents)
+
+    screen.getByText('Documents')
+    screen.getByText('File Description')
+    screen.getByText(description1)
+    screen.getByText(description2)
   })
 })

--- a/frontend/src/pages/authorizationDetails/AuthorizationDetails.tsx
+++ b/frontend/src/pages/authorizationDetails/AuthorizationDetails.tsx
@@ -76,7 +76,7 @@ export default function AuthorizationDetails() {
       <ApplicationStatusSection item={item} />
       <LocationSection item={item} />
       <DetailsSection item={item} />
-      <DocumentsSection />
+      <DocumentsSection item={item} />
     </Stack>
   )
 }

--- a/frontend/src/pages/authorizationDetails/DetailsBackButton.tsx
+++ b/frontend/src/pages/authorizationDetails/DetailsBackButton.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { useNavigate } from 'react-router'
 import { useLocation } from 'react-router-dom'
 import { Button } from '@mui/material'

--- a/frontend/src/pages/authorizationDetails/DetailsMap.tsx
+++ b/frontend/src/pages/authorizationDetails/DetailsMap.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { LatLngTuple } from 'leaflet'
 import { MapContainer, Marker, TileLayer } from 'react-leaflet'
 

--- a/frontend/src/pages/authorizationDetails/DocumentsSection.css
+++ b/frontend/src/pages/authorizationDetails/DocumentsSection.css
@@ -23,6 +23,8 @@
 }
 
 .document-table-link {
-  color: var(--typography-color-link, #255A90);
-  text-decoration-line: underline;
+  /* The links are not viewable yet so don't make them look like a link */
+  color: var(--typography-color-primary);
+  /* color: var(--typography-color-link); */
+  /* text-decoration-line: underline; */
 }

--- a/frontend/src/pages/authorizationDetails/DocumentsSection.css
+++ b/frontend/src/pages/authorizationDetails/DocumentsSection.css
@@ -6,25 +6,28 @@
 .documents-table-cell {
   background-color: var(--surface-color-background-white);
   border-bottom: 1px solid var(--surface-color-border-medium);
+  color: var(--typography-color-primary);
   padding: 8px;
   font-size: 12px;
-  color: var(--typography-color-secondary);
 }
 
 .documents-table-cell:last-child {
   border-bottom: none;
 }
 
+.documents-table-cell--no-data {
+  color: var(--typography-color-secondary);
+}
+
 .documents-table-cell--header {
-  border-bottom-color: var(--surface-color-border-medium);
   background-color: var(--surface-color-brand-gray-20);
+  border-bottom-color: var(--surface-color-border-medium);
+  color: var(--typography-color-secondary);
   border-radius: 4px 4px 0 0;
   font-weight: 700;
 }
 
-.document-table-link {
-  /* The links are not viewable yet so don't make them look like a link */
-  color: var(--typography-color-primary);
-  /* color: var(--typography-color-link); */
-  /* text-decoration-line: underline; */
+.documents-table-call--link {
+  color: var(--typography-color-link);
+  text-decoration-line: underline;
 }

--- a/frontend/src/pages/authorizationDetails/DocumentsSection.tsx
+++ b/frontend/src/pages/authorizationDetails/DocumentsSection.tsx
@@ -1,9 +1,26 @@
-import React from 'react'
 import { Stack, Typography } from '@mui/material'
+
+import {
+  useDocumentsStatus,
+  useFindAuthorizationDocuments,
+} from '@/features/omrr/documents-slice'
+import OmrrData from '@/interfaces/omrr'
+import { OmrrAuthzDocs } from '@/interfaces/omrr-documents'
 
 import './DocumentsSection.css'
 
-export function DocumentsSection() {
+interface Props {
+  item: OmrrData
+}
+
+export function DocumentsSection({ item }: Readonly<Props>) {
+  const status = useDocumentsStatus()
+  const documents = useFindAuthorizationDocuments(item['Authorization Number'])
+  if (status !== 'succeeded' || !Array.isArray(documents)) {
+    return null
+  }
+
+  const count = documents.length
   return (
     <Stack
       direction="column"
@@ -22,10 +39,19 @@ export function DocumentsSection() {
         <div className="documents-table-cell documents-table-cell--header">
           File Description
         </div>
-        <div className="documents-table-cell">
-          There are no documents to display.
-        </div>
-        {/* documents goes here */}
+        {count === 0 && (
+          <div className="documents-table-cell">
+            There are no documents to display.
+          </div>
+        )}
+        {documents.map((doc: OmrrAuthzDocs) => (
+          <div
+            key={`DocumentRow-${doc.DocumentObjectID}`}
+            className="documents-table-cell document-table-link"
+          >
+            {doc.Description}
+          </div>
+        ))}
       </Stack>
     </Stack>
   )

--- a/frontend/src/pages/authorizationDetails/DocumentsSection.tsx
+++ b/frontend/src/pages/authorizationDetails/DocumentsSection.tsx
@@ -1,4 +1,5 @@
 import { Stack, Typography } from '@mui/material'
+import clsx from 'clsx'
 
 import {
   useDocumentsStatus,
@@ -21,6 +22,8 @@ export function DocumentsSection({ item }: Readonly<Props>) {
   }
 
   const count = documents.length
+  // When the documents can be downloaded - change to a link
+  const canDownload = false
   return (
     <Stack
       direction="column"
@@ -40,14 +43,17 @@ export function DocumentsSection({ item }: Readonly<Props>) {
           File Description
         </div>
         {count === 0 && (
-          <div className="documents-table-cell">
+          <div className="documents-table-cell documents-table-cell--no-data">
             There are no documents to display.
           </div>
         )}
         {documents.map((doc: OmrrAuthzDocs) => (
           <div
             key={`DocumentRow-${doc.DocumentObjectID}`}
-            className="documents-table-cell document-table-link"
+            className={clsx(
+              'documents-table-cell',
+              canDownload && 'documents-table-cell--link',
+            )}
           >
             {doc.Description}
           </div>

--- a/frontend/src/pages/authorizationDetails/LocationSection.tsx
+++ b/frontend/src/pages/authorizationDetails/LocationSection.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { Box, Grid, Stack, Typography } from '@mui/material'
 import { useTheme } from '@mui/material/styles'
 import useMediaQuery from '@mui/material/useMediaQuery'

--- a/frontend/src/pages/authorizationList/ExportResultsButton.tsx
+++ b/frontend/src/pages/authorizationList/ExportResultsButton.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { Button } from '@mui/material'
 
 import { useFilteredResults } from '@/features/omrr/omrr-slice'

--- a/frontend/src/pages/authorizationList/ListLastUpdated.tsx
+++ b/frontend/src/pages/authorizationList/ListLastUpdated.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { useSelector } from 'react-redux'
 import { Typography } from '@mui/material'
 

--- a/frontend/src/pages/authorizationList/ListSearchResults.tsx
+++ b/frontend/src/pages/authorizationList/ListSearchResults.tsx
@@ -1,9 +1,8 @@
-import React from 'react'
+import { Box } from '@mui/material'
 
 import { NoResults } from '@/components/NoResults'
 import { AuthorizationListItem } from '@/components/AuthorizationListItem'
 import OmrrData from '@/interfaces/omrr'
-import { Box } from '@mui/material'
 
 interface Props {
   results: OmrrData[]

--- a/frontend/src/pages/dashboard/Dashboard.test.tsx
+++ b/frontend/src/pages/dashboard/Dashboard.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { screen } from '@testing-library/react'
 
 import { render } from '@/test-utils'

--- a/frontend/src/pages/dashboard/LearnMoreSection.tsx
+++ b/frontend/src/pages/dashboard/LearnMoreSection.tsx
@@ -56,7 +56,7 @@ export function LearnMoreSection() {
         />
         <LearnMoreCard
           title="Compliance and enforcement"
-          link="https://www2.gov.bc.ca/gov/content/environment/natural-resource-stewardship/natural-resource-law-enforcement/environmental-compliance"
+          link="https://www2.gov.bc.ca/gov/content/environment/research-monitoring-reporting/reporting/environmental-enforcement-reporting"
           icon={identity}
           actions="Search the compliance and enforcement database and learn
                     about how we coordinate oversight."

--- a/frontend/src/pages/map/MapView.test.tsx
+++ b/frontend/src/pages/map/MapView.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { fireEvent, screen } from '@testing-library/react'
 
 import { render } from '@/test-utils'

--- a/frontend/src/pages/map/drawer/SearchResultsList.test.tsx
+++ b/frontend/src/pages/map/drawer/SearchResultsList.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { fireEvent, screen } from '@testing-library/react'
 
 import { render } from '@/test-utils'

--- a/frontend/src/pages/map/search/MapSearch.test.tsx
+++ b/frontend/src/pages/map/search/MapSearch.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { screen } from '@testing-library/react'
 
 import { MapSearch } from './MapSearch'

--- a/frontend/src/pages/map/search/PointSearch.tsx
+++ b/frontend/src/pages/map/search/PointSearch.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { useDispatch } from 'react-redux'
 import { Button, Slider, Typography } from '@mui/material'
 import clsx from 'clsx'

--- a/frontend/src/pages/map/search/PolygonSearch.tsx
+++ b/frontend/src/pages/map/search/PolygonSearch.tsx
@@ -1,14 +1,13 @@
-import React from 'react'
 import { useDispatch } from 'react-redux'
 import { Button } from '@mui/material'
 import clsx from 'clsx'
 
 import { setActiveTool } from '@/features/map/map-slice'
+import { setPolygonFilter, usePolygonFilter } from '@/features/omrr/omrr-slice'
 
 import CloseIcon from '@/assets/svgs/fa-close.svg?react'
 import DeleteIcon from '@/assets/svgs/fa-trash.svg?react'
 import CheckIcon from '@/assets/svgs/fa-check.svg?react'
-import { setPolygonFilter, usePolygonFilter } from '@/features/omrr/omrr-slice'
 
 interface Props {
   isSmall?: boolean

--- a/frontend/src/pages/map/search/SearchAutocomplete.test.tsx
+++ b/frontend/src/pages/map/search/SearchAutocomplete.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { screen } from '@testing-library/react'
 
 import { render } from '@/test-utils'

--- a/frontend/src/service/api-service.ts
+++ b/frontend/src/service/api-service.ts
@@ -1,6 +1,5 @@
 import type { AxiosInstance } from 'axios'
 import axios from 'axios'
-import {env} from '@/env'
 import { isTest } from '@/constants/env'
 
 class APIService {
@@ -26,7 +25,7 @@ class APIService {
         }
       },
     )
-    console.info(env.VITE_AMS_URL)
+    // console.info(env.VITE_AMS_URL)
   }
 
   public getAxiosInstance(): AxiosInstance {

--- a/frontend/src/test-setup.ts
+++ b/frontend/src/test-setup.ts
@@ -11,6 +11,7 @@ import { cleanup } from '@testing-library/react'
 import { mockOmrrData } from '@/mocks/mock-omrr-data'
 import { mockPlaces } from '@/mocks/mock-places'
 import { mockOmrrApplicationStatusResponse } from '@/mocks/mock-omrr-application-status'
+import { mockOmrrDocuments } from '@/mocks/mock-omrr-documents'
 
 expect.extend(matchers)
 
@@ -138,6 +139,9 @@ const successHandlers = [
   http.get(`${baseUrl}/api/omrr/application-status`, () => {
     return HttpResponse.json(mockOmrrApplicationStatusResponse, { status: 200 })
   }),
+  http.get(`${baseUrl}/api/omrr/authorization-docs`, () => {
+    return HttpResponse.json(mockOmrrDocuments, { status: 200 })
+  }),
   http.get(`${baseUrl}/places.json`, () => {
     return HttpResponse.json(mockPlaces, { status: 200 })
   }),
@@ -160,7 +164,7 @@ beforeAll(() => {
 //  Close server after all tests
 afterAll(() => mswServer.close())
 
-// Reset handlers after each test `important for test isolation`
+// Reset handlers after each test (important for test isolation)
 afterEach(() => {
   cleanup()
   mswServer.resetHandlers()

--- a/frontend/src/test-utils.tsx
+++ b/frontend/src/test-utils.tsx
@@ -3,7 +3,7 @@ import { BrowserRouter, Route, Routes } from 'react-router-dom'
 import { render, RenderOptions } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
 import { Provider } from 'react-redux'
-import { RootState, setupStore } from '@/app/store'
+import { loadApiData, RootState, setupStore } from '@/app/store'
 
 interface TestRouterProps {
   children: ReactNode
@@ -42,15 +42,20 @@ interface TestStateProviderProps {
   children: ReactNode
   withStateProvider?: boolean
   initialState?: Partial<RootState>
+  withApiData?: boolean
 }
 
 function TestStateProvider({
   children,
   withStateProvider = false,
   initialState,
+  withApiData = false,
 }: Readonly<TestStateProviderProps>) {
   if (withStateProvider) {
     const store = setupStore(initialState)
+    if (withApiData) {
+      loadApiData(store)
+    }
     return <Provider store={store}>{children}</Provider>
   }
   return children
@@ -63,6 +68,7 @@ type CustomRenderOptions = Omit<RenderOptions, 'wrapper'> & {
   path?: string
   withStateProvider?: boolean
   initialState?: Partial<RootState>
+  withApiData?: boolean
 }
 
 function customRender(ui: ReactElement, options: CustomRenderOptions = {}) {
@@ -74,6 +80,7 @@ function customRender(ui: ReactElement, options: CustomRenderOptions = {}) {
     path,
     withStateProvider,
     initialState,
+    withApiData,
     ...restOptions
   } = options
   if (screenWidth !== undefined) {
@@ -86,6 +93,7 @@ function customRender(ui: ReactElement, options: CustomRenderOptions = {}) {
         <TestStateProvider
           withStateProvider={withStateProvider}
           initialState={initialState}
+          withApiData={withApiData}
         >
           {children}
         </TestStateProvider>


### PR DESCRIPTION
# Description

Load all authorization documents on start up, and display them on the Authorization Details page when the authorization number matches.

Also update the C&E link on the dashboard page.

Fixes #112 #90 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Unit tests
- [ ] End to end tests - can't be tested yet since there are no real authorization documents


## Checklist
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged

## Further comments

There are no authorization documents yet, so only the unit tests are there. But once the API returns documents, they should show up properly.


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-epd-organics-info-199-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-epd-organics-info-199-frontend.apps.silver.devops.gov.bc.ca/api/)

Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-epd-organics-info/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-epd-organics-info/actions/workflows/merge.yml)