### PR TITLE
fix: Marker click bug

### DIFF
--- a/frontend/src/components/DataLayersToggleGroup.tsx
+++ b/frontend/src/components/DataLayersToggleGroup.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import { useState } from 'react'
 import {
   Button,
   Checkbox,

--- a/frontend/src/components/Footer.test.tsx
+++ b/frontend/src/components/Footer.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { screen } from '@testing-library/react'
 
 import { render } from '@/test-utils'

--- a/frontend/src/components/LocationIconButton.test.tsx
+++ b/frontend/src/components/LocationIconButton.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { screen } from '@testing-library/react'
 import { LatLngTuple } from 'leaflet'
 

--- a/frontend/src/components/SearchByRadioGroup.tsx
+++ b/frontend/src/components/SearchByRadioGroup.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent } from 'react'
+import { ChangeEvent } from 'react'
 import { useDispatch } from 'react-redux'
 import { FormControlLabel, Radio, RadioGroup } from '@mui/material'
 import { RadioGroupProps } from '@mui/material/RadioGroup/RadioGroup'

--- a/frontend/src/components/SearchInput.tsx
+++ b/frontend/src/components/SearchInput.tsx
@@ -1,13 +1,14 @@
-import React, { MouseEventHandler } from 'react'
+import { MouseEventHandler } from 'react'
 import { IconButton, InputAdornment, TextField } from '@mui/material'
 import { TextFieldProps } from '@mui/material/TextField/TextField'
 import clsx from 'clsx'
+
+import { LocationIconButton } from './LocationIconButton'
 
 import SearchIcon from '@/assets/svgs/fa-search.svg?react'
 import CloseIcon from '@/assets/svgs/fa-close.svg?react'
 
 import './SearchInput.css'
-import { LocationIconButton } from '@/components/LocationIconButton'
 
 interface Props extends Omit<TextFieldProps, 'variant'> {
   showSearchIcon?: boolean

--- a/frontend/src/features/omrr/omrr-slice.ts
+++ b/frontend/src/features/omrr/omrr-slice.ts
@@ -239,7 +239,6 @@ export const useHasSearchTextFilter = () =>
   useSearchTextFilter().length >= MIN_SEARCH_LENGTH
 
 export const selectAllResults = (state: RootState) => state.omrr.allResults
-const selectAllResultsCount = (state: RootState) => state.omrr.allResults.length
 
 export const selectFilteredResults = (state: RootState) =>
   state.omrr.filteredResults
@@ -265,12 +264,6 @@ export const useFindByAuthorizationNumber = (
     )
   }
   return undefined
-}
-
-export const useAllResultsShowing = () => {
-  const allResultsCount = useSelector(selectAllResultsCount)
-  const filteredResultsCount = useSelector(selectFilteredResultsCount)
-  return filteredResultsCount === allResultsCount
 }
 
 const selectLastSearchTime = (state: RootState) => state.omrr.lastSearchTime

--- a/frontend/src/hooks/useSwipe.test.tsx
+++ b/frontend/src/hooks/useSwipe.test.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react'
+import { useRef } from 'react'
 import { fireEvent, render, screen } from '@testing-library/react'
 
 import { SwipeCallback, useSwipe } from './useSwipe'

--- a/frontend/src/pages/authorizationDetails/AuthorizationDetails.tsx
+++ b/frontend/src/pages/authorizationDetails/AuthorizationDetails.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react'
+import { useEffect } from 'react'
 import { useNavigate } from 'react-router'
 import { useParams } from 'react-router-dom'
 import { Grid, Stack, Typography } from '@mui/material'

--- a/frontend/src/pages/authorizationDetails/DetailsSection.tsx
+++ b/frontend/src/pages/authorizationDetails/DetailsSection.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react'
+import { ReactNode } from 'react'
 import { Grid, Stack, Typography } from '@mui/material'
 
 import OmrrData from '@/interfaces/omrr'

--- a/frontend/src/pages/authorizationList/ListSearchInput.tsx
+++ b/frontend/src/pages/authorizationList/ListSearchInput.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent } from 'react'
+import { ChangeEvent } from 'react'
 import { useDispatch } from 'react-redux'
 
 import {

--- a/frontend/src/pages/authorizationList/ListSearchSection.tsx
+++ b/frontend/src/pages/authorizationList/ListSearchSection.tsx
@@ -1,11 +1,11 @@
-import React, { useState } from 'react'
+import { useState } from 'react'
 import { Box, Button } from '@mui/material'
 import { ArrowDropDown, ArrowDropUp } from '@mui/icons-material'
+import clsx from 'clsx'
 
+import { FilterByCheckboxGroup } from '@/components/FilterByCheckboxGroup'
 import { ListSearchInput } from './ListSearchInput'
 import { ListSearchByGroup } from './ListSearchByGroup'
-import { FilterByCheckboxGroup } from '@/components/FilterByCheckboxGroup'
-import clsx from 'clsx'
 
 const styles = {
   searchByRow: {

--- a/frontend/src/pages/contactUs/ContactUs.test.tsx
+++ b/frontend/src/pages/contactUs/ContactUs.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { screen } from '@testing-library/react'
 
 import { render } from '@/test-utils'

--- a/frontend/src/pages/guidance/GuidancePage.test.tsx
+++ b/frontend/src/pages/guidance/GuidancePage.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { screen } from '@testing-library/react'
 
 import { DATA_LAYER_GROUPS } from '@/constants/data-layers'

--- a/frontend/src/pages/map/MapView.test.tsx
+++ b/frontend/src/pages/map/MapView.test.tsx
@@ -34,7 +34,7 @@ describe('Test suite for MapView', () => {
     })
   }
   it('should render the MapView with markers', async () => {
-    renderComponent(themeBreakpointValues.xxl)
+    const { user } = renderComponent(themeBreakpointValues.xxl)
 
     const mapView = screen.getByTestId('map-view')
     expect(mapView).not.toHaveClass('map-view--small')
@@ -43,11 +43,20 @@ describe('Test suite for MapView', () => {
     expect(markers.length > 0).toBe(true)
 
     screen.getByPlaceholderText('Search')
-    screen.getByRole('button', { name: 'Find Me' })
+    await screen.findByRole('button', { name: 'Find Me' })
     expect(screen.queryByTitle('Show the data layers')).not.toBeInTheDocument()
     expect(
       screen.queryByTitle('Show my location on the map'),
     ).not.toBeInTheDocument()
+
+    const showResults = screen.getByRole('button', { name: 'Show Results' })
+    await user.click(showResults)
+
+    const zoomToBtn = screen.getByRole('button', { name: 'Zoom To Results' })
+    await user.click(zoomToBtn)
+
+    const hideResults = screen.getByRole('button', { name: 'Hide Results' })
+    await user.click(hideResults)
   })
 
   it('should render the MapView with no markers on a small screen', async () => {
@@ -140,10 +149,10 @@ describe('Test suite for MapView', () => {
   it('should render the MapView and test polygon search', async () => {
     const { user } = renderComponent(themeBreakpointValues.xxl, mockOmrrData)
 
-    const pointSearchBtn = screen.getByRole('button', {
+    const polygonSearchBtn = screen.getByRole('button', {
       name: 'Polygon Search',
     })
-    await user.click(pointSearchBtn)
+    await user.click(polygonSearchBtn)
 
     const cancelBtn = screen.getByRole('button', { name: 'Cancel' })
     const deleteBtn = screen.getByRole('button', { name: 'Delete Last Point' })

--- a/frontend/src/pages/map/hooks/useSetSelectedItem.tsx
+++ b/frontend/src/pages/map/hooks/useSetSelectedItem.tsx
@@ -4,6 +4,7 @@ import { useDispatch } from 'react-redux'
 import OmrrData from '@/interfaces/omrr'
 import { setSelectedItem } from '@/features/map/map-slice'
 import { useZoomToAuthorization } from './useZoomTo'
+import { isTest } from '@/constants/env'
 
 /**
  * Selects a single OmrrData item.
@@ -20,7 +21,7 @@ export function useSetSelectedItem() {
       dispatch(setSelectedItem(item))
       // Make sure this item is visible on the map
       // Delay the map zoom until the sidebar/bottom drawer finish expanding
-      zoomTo(item, 300)
+      zoomTo(item, isTest ? 0 : 300)
     },
     [dispatch],
   )

--- a/frontend/src/pages/map/layers/AuthorizationMarker.tsx
+++ b/frontend/src/pages/map/layers/AuthorizationMarker.tsx
@@ -1,22 +1,20 @@
 import { Tooltip } from 'react-leaflet'
 
 import OmrrData from '@/interfaces/omrr'
-import { useSetSelectedItem } from '../hooks/useSetSelectedItem'
-import { IconMarker } from './IconMarker'
 import { blueIcon1x, blueIcon2x } from '@/constants/marker-icons'
+import { IconMarker } from './IconMarker'
 
 interface Props {
   item: OmrrData
   isSmall: boolean
+  onClick: () => void
 }
 
-export function AuthorizationMarker({ item, isSmall }: Readonly<Props>) {
-  const selectItem = useSetSelectedItem()
-
-  const onClick = () => {
-    selectItem(item)
-  }
-
+export function AuthorizationMarker({
+  item,
+  isSmall,
+  onClick,
+}: Readonly<Props>) {
   const title = item['Regulated Party']
   return (
     <IconMarker

--- a/frontend/src/pages/map/layers/AuthorizationMarkers.test.tsx
+++ b/frontend/src/pages/map/layers/AuthorizationMarkers.test.tsx
@@ -1,0 +1,153 @@
+import { screen } from '@testing-library/react'
+import { useSelector } from 'react-redux'
+
+import { render } from '@/test-utils'
+import {
+  initialState as initialOmrrState,
+  OmrrSliceState,
+} from '@/features/omrr/omrr-slice'
+import { mockOmrrData } from '@/mocks/mock-omrr-data'
+import {
+  initialState as initialMapState,
+  MapSliceState,
+  selectZoomPosition,
+  useSelectedItem,
+  ZoomPosition,
+} from '@/features/map/map-slice'
+import OmrrData from '@/interfaces/omrr'
+import { TestMapContainer } from './TestMapContainer'
+import { AuthorizationMarkers } from './AuthorizationMarkers'
+import { ActiveToolEnum, MIN_CIRCLE_RADIUS } from '@/constants/constants'
+
+interface State {
+  selectedItem?: OmrrData
+  zoomPosition?: ZoomPosition
+}
+
+describe('Test suite for AuthorizationMarkers', () => {
+  function renderComponent(
+    omrrState: Partial<OmrrSliceState> = {},
+    mapState: Partial<MapSliceState> = {},
+    screenWidth = 1500,
+  ) {
+    const state: State = {}
+
+    const TestComponent = () => {
+      Object.assign(state, {
+        selectedItem: useSelectedItem(),
+        zoomPosition: useSelector(selectZoomPosition),
+      })
+      return (
+        <TestMapContainer>
+          <AuthorizationMarkers />
+        </TestMapContainer>
+      )
+    }
+
+    const { user } = render(<TestComponent />, {
+      screenWidth,
+      withStateProvider: true,
+      initialState: {
+        omrr: {
+          ...initialOmrrState,
+          status: 'succeeded',
+          filteredResults: mockOmrrData,
+          ...omrrState,
+        },
+        map: {
+          ...initialMapState,
+          ...mapState,
+        },
+      },
+    })
+    return { user, state }
+  }
+
+  it('should not render AuthorizationMarkers if status is not succeeded', () => {
+    renderComponent({ status: 'failed' })
+    expect(
+      screen.queryByAltText('Authorization marker'),
+    ).not.toBeInTheDocument()
+  })
+
+  it('should not render AuthorizationMarkers if no items', () => {
+    renderComponent({ filteredResults: [] })
+    expect(
+      screen.queryByAltText('Authorization marker'),
+    ).not.toBeInTheDocument()
+  })
+
+  it('should render AuthorizationMarkers and click on marker', async () => {
+    const { user, state } = renderComponent()
+
+    const markers = screen.getAllByAltText('Authorization marker')
+    expect(markers).toHaveLength(mockOmrrData.length)
+
+    const [marker] = markers
+    await user.click(marker)
+
+    expect(state.selectedItem).toBe(mockOmrrData[0])
+    expect(state.zoomPosition).toBeDefined()
+  })
+
+  it('should render AuthorizationMarkers in polygon search mode and click on marker', async () => {
+    const { user, state } = renderComponent(
+      {},
+      { activeTool: ActiveToolEnum.polygonSearch },
+    )
+
+    const markers = screen.getAllByAltText('Authorization marker')
+    const [marker] = markers
+    // Click is ignored when in polygon search mode
+    await user.click(marker)
+
+    expect(state.selectedItem).toBeUndefined()
+  })
+
+  it('should render AuthorizationMarkers in polygon search mode with positions', async () => {
+    const { user, state } = renderComponent(
+      {
+        polygonFilter: {
+          positions: [[48.123, -123.123]],
+          finished: false,
+        },
+      },
+      { activeTool: ActiveToolEnum.polygonSearch },
+    )
+
+    const marker = screen.getAllByAltText('Authorization marker')[0]
+    expect(marker).toBeDefined()
+    await user.click(marker)
+
+    expect(state.selectedItem).toBeUndefined()
+  })
+
+  it('should render AuthorizationMarkers in point search mode and click on marker', async () => {
+    const { user, state } = renderComponent(
+      {},
+      { activeTool: ActiveToolEnum.pointSearch },
+    )
+
+    const markers = screen.getAllByAltText('Authorization marker')
+    const [marker] = markers
+    await user.click(marker)
+
+    expect(state.selectedItem).toBeUndefined()
+  })
+
+  it('should render AuthorizationMarkers in point search mode with radius', async () => {
+    const { user, state } = renderComponent(
+      {
+        circleFilter: { radius: MIN_CIRCLE_RADIUS },
+      },
+      { activeTool: ActiveToolEnum.pointSearch },
+      500,
+    )
+
+    const marker = screen.getAllByAltText('Authorization marker')[0]
+    expect(marker).toBeDefined()
+    await user.click(marker)
+
+    expect(state.selectedItem).toBeUndefined()
+  })
+})

--- a/frontend/src/pages/map/layers/AuthorizationMarkers.tsx
+++ b/frontend/src/pages/map/layers/AuthorizationMarkers.tsx
@@ -1,4 +1,4 @@
-import { useSelector } from 'react-redux'
+import { useSelector, useStore } from 'react-redux'
 import MarkerClusterGroup from 'react-leaflet-cluster'
 import { useTheme } from '@mui/material/styles'
 import useMediaQuery from '@mui/material/useMediaQuery'
@@ -6,15 +6,56 @@ import useMediaQuery from '@mui/material/useMediaQuery'
 import { selectStatus, useFilteredResults } from '@/features/omrr/omrr-slice'
 import OmrrData from '@/interfaces/omrr'
 import { AuthorizationMarker } from './AuthorizationMarker'
+import { useSetSelectedItem } from '@/pages/map/hooks/useSetSelectedItem'
+import { useCallback } from 'react'
+import { RootState } from '@/app/store'
+import { ActiveToolEnum } from '@/constants/constants'
+
+/**
+ * Looks at the activeTool value (map slice) and
+ * polygonFilter and circleFilter values (omrr slice) to
+ * determine if a polygon or point search is in progress.
+ * This is not reactive, and is intended for use inside an event handler.
+ * This is safe according to the Redux docs:
+ * @see https://react-redux.js.org/api/hooks#usestore
+ */
+function useShapeFilterInProgress() {
+  const store = useStore<RootState>()
+
+  return useCallback((): boolean => {
+    const { omrr, map } = store.getState()
+    const { activeTool } = map
+    const { polygonFilter, circleFilter } = omrr
+    if (activeTool === ActiveToolEnum.polygonSearch) {
+      // When the polygon search tool is active but not finished
+      return polygonFilter ? !polygonFilter.finished : true
+    }
+    // When the point search tool is active, but the center point isn't defined
+    if (activeTool === ActiveToolEnum.pointSearch) {
+      return circleFilter ? !circleFilter.center : true
+    }
+    return false
+  }, [store])
+}
 
 export function AuthorizationMarkers() {
   const values = useFilteredResults()
   const status = useSelector(selectStatus)
   const theme = useTheme()
   const isSmall = useMediaQuery(theme.breakpoints.down('sm'))
+  const selectItem = useSetSelectedItem()
+  const isShapeSearchInProgressFn = useShapeFilterInProgress()
 
   const hasMarkers =
     status === 'succeeded' && Array.isArray(values) && values.length > 0
+
+  const onClick = (item: OmrrData) => {
+    // Disable clicks on markers when polygon/point search are in progress
+    const shapeSearchInProgress = isShapeSearchInProgressFn()
+    if (!shapeSearchInProgress) {
+      selectItem(item)
+    }
+  }
 
   return hasMarkers ? (
     <MarkerClusterGroup
@@ -28,6 +69,7 @@ export function AuthorizationMarkers() {
           key={`AuthorizationMarker-${item['Authorization Number']}`}
           item={item}
           isSmall={isSmall}
+          onClick={() => onClick(item)}
         />
       ))}
     </MarkerClusterGroup>

--- a/frontend/src/pages/map/layers/CrosshairsTooltipMarker.tsx
+++ b/frontend/src/pages/map/layers/CrosshairsTooltipMarker.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useRef } from 'react'
+import { ReactNode, useRef } from 'react'
 import {
   LatLngExpression,
   LeafletMouseEvent,

--- a/frontend/src/pages/map/layers/FindMeControl.test.tsx
+++ b/frontend/src/pages/map/layers/FindMeControl.test.tsx
@@ -1,0 +1,37 @@
+import { screen, waitForElementToBeRemoved } from '@testing-library/react'
+import { Mock } from 'vitest'
+
+import { render } from '@/test-utils'
+import { FindMeControl } from './FindMeControl'
+
+describe('Test suite for FindMeControl', () => {
+  it('should render FindMeControl', async () => {
+    const { user } = render(<FindMeControl />, {
+      withStateProvider: true,
+    })
+
+    const btn = screen.getByTitle('Show my location on the map')
+    expect(btn).not.toHaveClass('map-control-button--active')
+
+    await user.click(btn)
+
+    expect(btn).toHaveClass('map-control-button--active')
+  })
+
+  it('should not render FindMeControl when no permission', async () => {
+    const queryMock = navigator.permissions.query as Mock
+    queryMock.mockResolvedValueOnce({
+      name: 'geolocation',
+      state: 'denied',
+    })
+
+    render(<FindMeControl />, {
+      withStateProvider: true,
+    })
+
+    // Initially shows up until permissions query resolves
+    await waitForElementToBeRemoved(() =>
+      screen.getByTitle('Show my location on the map'),
+    )
+  })
+})

--- a/frontend/src/pages/map/layers/FindMeControl.tsx
+++ b/frontend/src/pages/map/layers/FindMeControl.tsx
@@ -6,12 +6,18 @@ import {
   setMyLocationVisible,
   useMyLocationVisible,
 } from '@/features/map/map-slice'
+import { useGeolocationPermission } from '@/hooks/useMyLocation'
 
 import GpsIcon from '@/assets/svgs/fa-gps.svg?react'
 
 export function FindMeControl() {
   const dispatch = useDispatch()
   const isMarkerVisible = useMyLocationVisible()
+  const state = useGeolocationPermission()
+  // No point in showing the button if the permission has been denied
+  if (state === 'denied') {
+    return null
+  }
 
   const onClick = () => {
     dispatch(setMyLocationVisible(!isMarkerVisible))

--- a/frontend/src/pages/map/layers/TestMapContainer.tsx
+++ b/frontend/src/pages/map/layers/TestMapContainer.tsx
@@ -1,0 +1,91 @@
+import { ReactNode, useEffect } from 'react'
+import { LatLngExpression } from 'leaflet'
+import { MapContainer, useMap } from 'react-leaflet'
+
+import { MapZoom } from './MapZoom'
+
+interface Props {
+  center?: LatLngExpression
+  zoom?: number
+  zoomControl?: boolean
+  children: ReactNode
+}
+
+export function TestMapContainer({
+  center = [48, -123],
+  zoom = 13,
+  zoomControl = false,
+  children,
+}: Readonly<Props>) {
+  return (
+    <MapContainer center={center} zoom={zoom} zoomControl={zoomControl}>
+      <FixMap />
+      <MapZoom />
+      {children}
+    </MapContainer>
+  )
+}
+
+/**
+ * There is a bug/issue with the user-event v14 library
+ * and leaflet that causes click events to throw a NaN error.
+ * This is an ugly workaround.
+ * @see https://stackoverflow.com/questions/70791283/testing-react-leaflet-marker-click-event-triggers-error-invalid-latlng-object
+ */
+export function FixMap() {
+  const map = useMap()
+
+  useEffect(() => {
+    const container = map.getContainer()
+    // First leaflet container to have a fixed size
+    if (container.clientWidth === 0) {
+      Object.defineProperty(container, 'clientWidth', { value: 800 })
+      Object.defineProperty(container, 'clientHeight', { value: 600 })
+    }
+
+    // Fix bug where Util.extend doesn't clone getters properly
+    const mapAny: any = map
+    const realFireDOMEvent = mapAny._fireDOMEvent
+    mapAny._fireDOMEvent = (e: any, type: string, canvasTargets: any) => {
+      if (type === 'click') {
+        // the clientX and clientY getter properties are defined on the parent MouseEvent class
+        // when leaflet clones the event object to fire the 'preclick' event
+        // these properties are not copied and are therefore undefined
+        const { target, currentTarget, srcElement } = e
+        e = new MouseEvent(type, {
+          button: e.button,
+          buttons: e.buttons,
+          clientX: e.clientX,
+          clientY: e.clientY,
+          relatedTarget: e.target,
+          screenX: e.screenX,
+          screenY: e.screenY,
+          altKey: e.altKey,
+          ctrlKey: e.ctrlKey,
+          shiftKey: e.shiftKey,
+          metaKey: e.metaKey,
+          detail: e.detail,
+          view: e.view,
+          bubbles: e.bubbles,
+          cancelable: e.cancelable,
+          composed: e.composed,
+        })
+        Object.defineProperty(e, 'target', {
+          value: target,
+          enumerable: true,
+        })
+        Object.defineProperty(e, 'currentTarget', {
+          value: currentTarget,
+          enumerable: true,
+        })
+        Object.defineProperty(e, 'srcElement', {
+          value: srcElement,
+          enumerable: true,
+        })
+      }
+      return realFireDOMEvent.call(map, e, type, canvasTargets)
+    }
+  }, [map])
+
+  return null
+}

--- a/frontend/src/pages/map/search/FindMeButton.test.tsx
+++ b/frontend/src/pages/map/search/FindMeButton.test.tsx
@@ -1,0 +1,37 @@
+import { screen, waitForElementToBeRemoved } from '@testing-library/react'
+
+import { FindMeButton } from './FindMeButton'
+import { render } from '@/test-utils'
+import { Mock } from '~/vitest'
+
+describe('Test suite for FindMeButton', () => {
+  it('should render FindMeButton', async () => {
+    const { user } = render(<FindMeButton />, {
+      withStateProvider: true,
+    })
+
+    const btn = screen.getByRole('button', { name: 'Find Me' })
+    expect(btn).not.toHaveClass('map-button--active')
+
+    await user.click(btn)
+
+    expect(btn).toHaveClass('map-button--active')
+  })
+
+  it('should not render FindMeButton when no permission', async () => {
+    const queryMock = navigator.permissions.query as Mock
+    queryMock.mockResolvedValueOnce({
+      name: 'geolocation',
+      state: 'denied',
+    })
+
+    render(<FindMeButton />, {
+      withStateProvider: true,
+    })
+
+    // Initially shows up until permissions query resolves
+    await waitForElementToBeRemoved(() =>
+      screen.getByRole('button', { name: 'Find Me' }),
+    )
+  })
+})

--- a/frontend/src/pages/map/search/FindMeButton.tsx
+++ b/frontend/src/pages/map/search/FindMeButton.tsx
@@ -6,12 +6,18 @@ import {
   setMyLocationVisible,
   useMyLocationVisible,
 } from '@/features/map/map-slice'
+import { useGeolocationPermission } from '@/hooks/useMyLocation'
 
 import FindMeIcon from '@/assets/svgs/fa-gps.svg?react'
 
 export function FindMeButton() {
   const dispatch = useDispatch()
   const isMarkerVisible = useMyLocationVisible()
+  const state = useGeolocationPermission()
+  // No point in showing the button if the permission has been denied
+  if (state === 'denied') {
+    return null
+  }
 
   const onClick = () => {
     dispatch(setMyLocationVisible(!isMarkerVisible))


### PR DESCRIPTION
# Description

Fixed a bug where the user could click on a marker while the polygon or point search was in progress, causing the map to zoom in. Instead the click is now ignored until the search is finished.

Also hid the Find Me buttons when the permission is explicitly `denied`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Unit tests

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-epd-organics-info-208-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-epd-organics-info-208-frontend.apps.silver.devops.gov.bc.ca/api/)

Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-epd-organics-info/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-epd-organics-info/actions/workflows/merge.yml)