### PR TITLE
fix(ci): allow trivy to fail (temporary)

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -98,3 +98,12 @@ jobs:
         with:
           sarif_file: "trivy-results.sarif"
 
+  results:
+    name: Analysis Results
+    if: always()
+    needs: [tests] # Restore trivy when/if fixed
+    runs-on: ubuntu-24.04
+    steps:
+      - if: contains(needs.*.result, 'failure')
+        run: echo "At least one job has failed." && exit 1
+      - run: echo "Success!"


### PR DESCRIPTION
Trivy has been having problems, so it has been removed from Analysis Results needs in analysis.yml.  Ideally this can be restored when they're no longer having issues.  To allow this failure reusable-tests-repo.yml had to be rolled into analysis.yml.

```
  results:
    name: Analysis Results
    if: always()
    needs: [..., trivy] # Restore trivy when/if fixed
```