### PR TITLE
chore(ci): switch to GitHub default CodeQL (remove our job)

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -57,23 +57,6 @@ jobs:
           sonar_token: ${{ secrets[matrix.token] }}
           triggers: ('${{ matrix.dir }}/')
 
-  codeql:
-    name: CodeQL
-    if: ${{ ! github.event.pull_request.draft }}
-    needs: [tests]
-    runs-on: ubuntu-24.04
-    timeout-minutes: 5
-    steps:
-      - uses: actions/checkout@v4
-      - uses: github/codeql-action/init@v3
-        with:
-          languages: javascript
-
-      - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
-        with:
-          category: "/language:javascript"
-
   # https://github.com/marketplace/actions/aqua-security-trivy
   trivy:
     name: Trivy Security Scan
@@ -101,7 +84,7 @@ jobs:
   results:
     name: Analysis Results
     if: always()
-    needs: [tests, codeql] # Restore trivy when/if fixed
+    needs: [tests] # Restore trivy when/if fixed
     runs-on: ubuntu-24.04
     steps:
       - if: contains(needs.*.result, 'failure')


### PR DESCRIPTION
Switch to GitHub default CodeQL, so we don't have to maintain our own job.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-epd-organics-info-310-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-epd-organics-info-310-frontend.apps.silver.devops.gov.bc.ca/api/)

Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-epd-organics-info/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-epd-organics-info/actions/workflows/merge.yml)