### PR TITLE
feat: Added document type to the document list

### DIFF
--- a/frontend/src/pages/authorizationDetails/AuthorizationDetails.test.tsx
+++ b/frontend/src/pages/authorizationDetails/AuthorizationDetails.test.tsx
@@ -143,7 +143,5 @@ describe('Test suite for AuthorizationDetails', () => {
 
     screen.getByText('Documents')
     screen.getByText('File Description')
-    screen.getByText('test-file.pdf')
-    screen.getByText('sample-file.pdf')
   })
 })

--- a/frontend/src/pages/authorizationDetails/DocumentsSection.tsx
+++ b/frontend/src/pages/authorizationDetails/DocumentsSection.tsx
@@ -60,6 +60,7 @@ export function DocumentsSection({ item }: Readonly<Props>) {
           </div>
         )}
         {documents.map((doc: OmrrAuthzDocs) => {
+          console.log(doc)
           const extension =
             (doc.Filename ?? '').split('.').pop()?.toUpperCase() || 'DOC'
           return (

--- a/frontend/src/pages/authorizationDetails/DocumentsSection.tsx
+++ b/frontend/src/pages/authorizationDetails/DocumentsSection.tsx
@@ -60,7 +60,6 @@ export function DocumentsSection({ item }: Readonly<Props>) {
           </div>
         )}
         {documents.map((doc: OmrrAuthzDocs) => {
-          console.log(doc)
           const extension =
             (doc.Filename ?? '').split('.').pop()?.toUpperCase() || 'DOC'
           return (

--- a/frontend/src/pages/authorizationDetails/DocumentsSection.tsx
+++ b/frontend/src/pages/authorizationDetails/DocumentsSection.tsx
@@ -48,24 +48,28 @@ export function DocumentsSection({ item }: Readonly<Props>) {
             There are no documents to display.
           </div>
         )}
-        {documents.map((doc: OmrrAuthzDocs) => (
-          <Link
-            key={`DocumentRow-${doc.DocumentObjectID}`}
-            className={clsx(
-              'documents-table-cell',
-              canDownload && 'documents-table-cell--link',
-            )}
-            href={
-              env.VITE_AMS_URL +
-              'download.aspx?PosseObjectId=' +
-              doc.DocumentObjectID
-            }
-            target="_blank"
-            rel={canDownload ? 'noopener noreferrer' : ''}
-          >
-            {doc.Description}
-          </Link>
-        ))}
+        {documents.map((doc: OmrrAuthzDocs) => {
+          const extension =
+            (doc.Filename ?? '').split('.').pop()?.toUpperCase() || 'DOC'
+          return (
+            <Link
+              key={`DocumentRow-${doc.DocumentObjectID}`}
+              className={clsx(
+                'documents-table-cell',
+                canDownload && 'documents-table-cell--link',
+              )}
+              href={
+                env.VITE_AMS_URL +
+                'download.aspx?PosseObjectId=' +
+                doc.DocumentObjectID
+              }
+              target="_blank"
+              rel={canDownload ? 'noopener noreferrer' : ''}
+            >
+              {doc.Description} ({extension})
+            </Link>
+          )
+        })}
       </Stack>
     </Stack>
   )

--- a/frontend/src/pages/authorizationDetails/DocumentsSection.tsx
+++ b/frontend/src/pages/authorizationDetails/DocumentsSection.tsx
@@ -39,6 +39,17 @@ export function DocumentsSection({ item }: Readonly<Props>) {
       <Typography fontWeight={700} color="#000" fontSize="24px">
         Documents
       </Typography>
+      <Typography fontSize="16px" color="#666" fontStyle="italic">
+        Authorization document(s) presented are publicly available document(s)
+        hosted on the{' '}
+        <a
+          href="https://www2.gov.bc.ca/gov/content/environment/waste-management/waste-discharge-authorization/find-authorization"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Authorization Management System
+        </a>
+      </Typography>
       <Stack className="documents-table" direction="column">
         <div className="documents-table-cell documents-table-cell--header">
           File Description

--- a/frontend/src/pages/authorizationDetails/DocumentsSection.tsx
+++ b/frontend/src/pages/authorizationDetails/DocumentsSection.tsx
@@ -61,7 +61,8 @@ export function DocumentsSection({ item }: Readonly<Props>) {
         )}
         {documents.map((doc: OmrrAuthzDocs) => {
           const extension =
-            (doc.Filename ?? '').split('.').pop()?.toUpperCase() || 'DOC'
+            (doc.Filename ?? '').match(/\.([^.]+)$/)?.[1]?.toUpperCase() ||
+            'DOC'
           return (
             <Link
               key={`DocumentRow-${doc.DocumentObjectID}`}


### PR DESCRIPTION
- Document extension/type added to the documents list.
- Defaults to (DOC)
![Screenshot from 2025-01-31 10-24-35](https://github.com/user-attachments/assets/14450c0c-76c3-4a0a-a76f-abed1a839acb)


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-epd-organics-info-372-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-epd-organics-info-372-frontend.apps.silver.devops.gov.bc.ca/api/)

Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-epd-organics-info/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-epd-organics-info/actions/workflows/merge.yml)