### PR TITLE
fix: pipeline to run e2e and remove deploy triggers

### DIFF
--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -14,7 +14,7 @@ on:
         description: Autoscaling enabled or not for the deployments
         required: false
         type: string
-        default: true
+        default: 'true'
       environment:
         description: Environment name; omit for PRs
         required: false
@@ -50,10 +50,7 @@ on:
         default: ""
         required: false
         type: string
-    outputs:
-      triggered:
-        description: 'Has a deployment has been triggered?'
-        value: ${{ jobs.deploys.outputs.triggered }}
+
 
 env:
   repo_release: ${{ github.event.repository.name }}-${{ inputs.release }}
@@ -65,8 +62,6 @@ jobs:
     name: Helm
     environment: ${{ inputs.environment }}
     runs-on: ubuntu-24.04
-    outputs:
-      triggered: ${{ steps.triggers.outputs.triggered }}
     timeout-minutes: ${{ inputs.timeout-minutes }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -37,7 +37,6 @@ jobs:
       autoscaling: false
       tag: ${{ github.event.number }}
       release: ${{ github.event.number }}
-      triggers: ('backend/' 'frontend/' 'charts/' '.github/')
       params: |
         --set backend.pdb.enabled=false \
         --set frontend.pdb.enabled=false \
@@ -48,7 +47,6 @@ jobs:
 
   tests:
     name: Tests
-    if: needs.deploys.outputs.triggered == 'true'
     needs: [deploys]
     uses: ./.github/workflows/.tests.yml
     with:


### PR DESCRIPTION
currently the e2e are not running since triggers are not coming back, removed triggers from PR, it is ok to deploy PRs and run e2e, builds are still triggered based.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-epd-organics-info-383-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-epd-organics-info-383-frontend.apps.silver.devops.gov.bc.ca/api/)

Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-epd-organics-info/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-epd-organics-info/actions/workflows/merge.yml)